### PR TITLE
Added missing dependencies to run Epinano_Variant.py

### DIFF
--- a/HelloWorld.ipynb
+++ b/HelloWorld.ipynb
@@ -1,0 +1,108 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "HelloWorld",
+      "provenance": [],
+      "collapsed_sections": [],
+      "authorship_tag": "ABX9TyOqvEWar5YyK+BZoPjn5J08",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/kxk302/EpiNano/blob/master/HelloWorld.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "PqLShW5xqXca"
+      },
+      "source": [
+        "print(\"Hello World\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-9wOapNaskFc"
+      },
+      "source": [
+        "This is **bold** \\\\\n",
+        "This is *italic* \\\\\n",
+        "This is ~strikethrough~ \\\\\n",
+        "$\\sqrt{3x-1}+(1+x)$ \\\\\n",
+        "$e^{x} = \\sum_{i=0}^{\\infty}\\frac{1}{i!}x^{i}$ \\\\\n",
+        "Constraints are \\\\\n",
+        "- $x + y = 1$\n",
+        "- $x^{2} + y^{2} = 1$\n",
+        "\n",
+        "$\\beta, u_{i}(t), \\hat{x}(t), x_{i1,k}(t), \\exp, \\pi, \\in$"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "4xZZFo8qoc4U",
+        "outputId": "a6a0b667-3c69-4da9-f1a8-b039587aef2b"
+      },
+      "source": [
+        "import time\n",
+        "print(time.ctime())"
+      ],
+      "execution_count": 17,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Fri Feb  5 14:48:20 2021\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "CnfLaak6ooEZ",
+        "outputId": "5d411de3-e935-45d4-9669-a19a4092e4b9"
+      },
+      "source": [
+        "import time\n",
+        "time.sleep(1)\n",
+        "print(time.ctime())"
+      ],
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Fri Feb  5 14:48:01 2021\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    }
+  ]
+}

--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -6,6 +6,7 @@ python -m venv epinano1.2_venv
 source epinano1.2_venv/bin/activate
 
 pip install pandas==0.25.1
-
 pip install dask==2.5.2
-
+pip install toolz==0.11.1
+pip install fsspec==0.3.3
+pip install cloudpickle==1.6.0


### PR DESCRIPTION
In order to run the command 'python3 Epinano_variant.py -h', I had to add the following dependencies to INSTALL.h file. Afterwards, the command 'python3 Epinano_variant.py -h' runs without erroring out on missing dependencies.

